### PR TITLE
Implement a crawler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,25 +16,3 @@ RUN mkdir -p $PARENT_DIR
 
 FROM base as dev
 ENTRYPOINT $CRAWLER_DIR/dev-container-setup.sh
-#ENTRYPOINT $CRAWLER_DIR/crawler_start.sh
-#VOLUME [ "/opt/app-root/src/recipe-crawler", "/opt/app-root/src/recipe-scrapers" ]
-
-
-#FROM base as prod
-#
-#WORKDIR $PARENT_DIR
-#RUN git clone -b $CRAWLER_GIT_BRANCH $CRAWLER_GIT_REPO
-##WORKDIR $CRAWLER_DIR
-#WORKDIR recipe-crawler
-#RUN pwd 1>&2
-#RUN ls -l $PARENT_DIR >> /tmp/allcrawl_src.log
-#RUN ls -l $CRAWLER_DIR >> /tmp/allcrawl_app.log
-##RUN pip3 install -r $CRAWLER_DIR/requirements.txt
-#
-#RUN git clone -b $SCRAPER_GIT_BRANCH $SCRAPER_GIT_REPO
-#WORKDIR $SCRAPER_DIR
-#RUN pwd
-#RUN ls -l $PARENT_DIR >> /tmp/allcrawl_src.log
-#RUN ls -l $SCRAPER_DIR >> /tmp/scraper_app.log
-##RUN pip3 install -r $SCRAPER_DIR/requirements-dev.txt
-##RUN python3 setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3.8 AS base
+
+ENV DOCKER_BUILDKIT 0
+ENV COMPOSE_DOCKER_CLI_BUILD 0
+
+ENV PARENT_DIR /opt/app-root/src
+ENV CRAWLER_DIR $PARENT_DIR/recipe-crawler
+ENV SCRAPER_DIR $PARENT_DIR/recipe-scrapers
+
+ENV CRAWLER_GIT_REPO https://github.com/Kevin-Prichard/recipes-crawler
+ENV CRAWLER_GIT_BRANCH master
+ENV SCRAPER_GIT_REPO https://github.com/Kevin-Prichard/recipe-scrapers
+ENV SCRAPER_GIT_BRANCH develop_add-allrecipes-extended_nutritients
+
+RUN mkdir -p $PARENT_DIR
+
+FROM base as dev
+ENTRYPOINT $CRAWLER_DIR/dev-container-setup.sh
+#ENTRYPOINT $CRAWLER_DIR/crawler_start.sh
+#VOLUME [ "/opt/app-root/src/recipe-crawler", "/opt/app-root/src/recipe-scrapers" ]
+
+
+#FROM base as prod
+#
+#WORKDIR $PARENT_DIR
+#RUN git clone -b $CRAWLER_GIT_BRANCH $CRAWLER_GIT_REPO
+##WORKDIR $CRAWLER_DIR
+#WORKDIR recipe-crawler
+#RUN pwd 1>&2
+#RUN ls -l $PARENT_DIR >> /tmp/allcrawl_src.log
+#RUN ls -l $CRAWLER_DIR >> /tmp/allcrawl_app.log
+##RUN pip3 install -r $CRAWLER_DIR/requirements.txt
+#
+#RUN git clone -b $SCRAPER_GIT_BRANCH $SCRAPER_GIT_REPO
+#WORKDIR $SCRAPER_DIR
+#RUN pwd
+#RUN ls -l $PARENT_DIR >> /tmp/allcrawl_src.log
+#RUN ls -l $SCRAPER_DIR >> /tmp/scraper_app.log
+##RUN pip3 install -r $SCRAPER_DIR/requirements-dev.txt
+##RUN python3 setup.py install

--- a/crawl_coordinator.py
+++ b/crawl_coordinator.py
@@ -1,0 +1,97 @@
+import multiprocessing.dummy as mp
+import re
+import requests
+import sys
+from typing import List
+from threading import Thread, Lock
+
+mutex = Lock()
+
+from datastore import RecipeStore
+
+# from recipe_scrapers import scrape_me
+from recipe_scrapers._abstract import AbstractScraper
+
+
+# https://www.madelyneriksen.com/blog/simple-concurrency-python-multiprocessing
+
+class CrawlCoordinator:
+    DISCOVERY_CLIENT_THREADS = 4
+    DISCOVERY_SINK_THREADS = 1
+
+    def __init__(self, scraper_classes: List[type(AbstractScraper)]):
+        self.scraper_classes = scraper_classes
+        self.store = RecipeStore()
+
+    def start(self):
+        # import pudb; pu.db
+        url_gen = self._start_discovery() <- isn\'t a generator
+        try:
+            while True:
+                print("start...")
+                url = next(url_gen)  <- NoneType is not an iterator
+                print("CrawlCoordinator.start: " + url)
+        except StopIteration:
+            import pudb; pu.db
+            print("Finished URL discovery")
+            return
+
+    def _start_discovery(self):
+        # site_explorers = [RecipeSiteUrlIterator(klass)
+        #                   for klass in self.scraper_classes]
+        # sites_completed = 0
+        urls_counted = 0
+
+        with mp.Pool(4*len(self.scraper_classes)) as dpool:
+            RECIPE_ID_REGEX = re.compile(r".*[^/]+/(\d+)$")
+            found_ids = []
+            site_iterator = dpool.imap_unordered(
+                CrawlCoordinator.discovery_runner,
+                self.scraper_classes)
+
+            try:
+                while True:
+                    # print("_start_discovery ...1")
+                    item = next(site_iterator)
+                    while True:
+                        # print("_start_discovery ...2")
+                        an_item = next(item)
+                        recipe_id = RECIPE_ID_REGEX.match(an_item).groups()[0]
+                        mutex.acquire()
+                        try:
+                            found_ids.append(int(recipe_id))
+                            urls_counted += 1
+                            # print("_start_discovery ...3 " +
+                            #       str(an_item) + "    " + str(urls_counted))
+                            if urls_counted / 100 == int(urls_counted / 100):
+                                sys.stderr.write(
+                                    "urls_counted: " + str(urls_counted) + "\n")
+                        finally:
+                            mutex.release()
+            except StopIteration as ee:
+                print("_start_discovery: StopIteration")
+                    # print("_start_discovery 4 "+str(item))
+                    # except StopIteration:
+
+                found_ids = sorted(found_ids)
+                for i in range(0, 9999):
+                    if found_ids[i] != i + 1:
+                        import pudb; pu.db
+                return
+
+
+    @classmethod
+    def discovery_runner(cls, scraper_class):
+        # import pudb; pu.db
+        # print("discovery_runner startup")
+        site_iter = scraper_class.site_iterator(None, 1, 10000)
+        # print("discovery_runner site_iter: "+str(site_iter))
+        try:
+            while True:
+                # print("d-r...")
+                recipe_url = next(site_iter)
+                # print("d-r: ... recipe_url = " + str(recipe_url))
+                yield recipe_url
+        except StopIteration:
+            print("discovery_runner StopIteration")
+            return

--- a/crawl_coordinator.py
+++ b/crawl_coordinator.py
@@ -1,15 +1,20 @@
+import logging
 import multiprocessing.dummy as mp
 import random
 import re
+import threading
+
 import requests
 from requests.packages.urllib3.util import Url
 import sys
+import time
 from typing import List, Callable
 from threading import Thread, Lock
+from simple_classproperty import classproperty
 
 mutex = Lock()
 
-from datastore import RecipeStore
+from datastore import RecipeStore, EmptyQueueException
 import json
 from recipe_scrapers import scrape_me
 from recipe_scrapers._abstract import AbstractScraper
@@ -17,8 +22,11 @@ from recipe_scrapers._abstract import AbstractScraper
 
 # https://www.madelyneriksen.com/blog/simple-concurrency-python-multiprocessing
 
-THREADS_DISCOVERY_HTTP_CLIENT = 1
-THREADS_FETCH_HTTP_DOC = 1
+THREADS_DISCOVERY_HTTP_CLIENT = 10
+THREADS_FETCH_HTTP_DOC = 10
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
 
 
 class CrawlCoordinator:
@@ -28,12 +36,62 @@ class CrawlCoordinator:
                  should_process_recipe: Callable[[Url], None],
                  process_recipe: Callable[[Url], bool],
                  ):
+        self._should_process_recipe = should_process_recipe
         self.scraper_classes = scraper_classes
-        self.store = RecipeStore()
+        self.store = RecipeStore.instance
 
     def start(self):
-        self._run_discovery()
-        self._run_retrieval()
+        thread_scrape = Thread(target=self._run_scrape)
+        thread_scrape.start()
+
+        thread_discovery = Thread(target=self._run_discovery)
+        thread_discovery.start()
+        # thread_discovery.setDaemon(True)
+
+
+        thread_discovery.join()
+        thread_scrape.join()
+
+    def _run_scrape(self):
+
+        with mp.Pool(THREADS_FETCH_HTTP_DOC) as scrape_pool:
+            scrape_iterator = scrape_pool.imap_unordered(
+                self._scrape, self._scrape_target_generator()
+            )
+            try:
+                while True:
+                    result = next(scrape_iterator)
+                    # print(result)
+            except StopIteration:
+                print("_run_scrape: done scraping")
+
+    def _scrape(self, recipe_uri: Url):
+        # print("Recipe scrape: %s" % str(recipe_uri))
+        if self.store.have_recipe(recipe_uri):
+            logger.warning("Skipping2 %s" % str(recipe_uri))
+            return
+        recipe = scrape_me(str(recipe_uri))
+        d = recipe.to_dict(unitized=True, uri=str(recipe_uri))
+        if d['canonical_url'] != str(recipe_uri):
+            raise ValueError(
+                "Found unmatching uri, d['canonical_url'] != str(recipe_uri) "
+                f"-> %s '{d['canonical_url']}' != '{str(recipe_uri)}'")
+        d['domain'] = recipe_uri.hostname
+        # print("Recipe scraped: %s (%d)" % (recipe_uri, len(json.dumps(d))))
+        result = self.store.upsert_recipe(d)
+        self.store.dequeue_finish(recipe_uri)
+        # print("Recipe upsert result: %s" % str(result.raw_result))
+
+    def _scrape_target_generator(self):
+        while True:
+            try:
+                recipe_uri = self.store.dequeue()
+                if recipe_uri:
+                    yield recipe_uri
+                else:
+                    time.sleep(0.1)
+            except EmptyQueueException:
+                time.sleep(0.1)
 
     def _run_discovery(self):
         # site_explorers = [RecipeSiteUrlIterator(klass)
@@ -47,35 +105,54 @@ class CrawlCoordinator:
                                          re.I)
             found_ids = []
             site_iterator = dpool.imap_unordered(
-                CrawlCoordinator.discovery_runner,
+                self.discovery_runner,
                 self.scraper_classes)
 
             try:
                 while True:
                     print("_start_discovery ...1")
-                    item = next(site_iterator)
-                    print("_start_discovery ...1 ", str(item))
+                    permalink_block = next(site_iterator)
+                    print("_start_discovery ...1 ", str(permalink_block))
                     while True:
                         # print("_start_discovery ...2")
-                        recipe_permalink = next(item)
+                        recipe_permalink = next(permalink_block)
                         if not recipe_permalink:
+                            print("_run_discovery: recipe_permalink is None, "
+                                  "continueing")
                             continue
-                        recipe_id = RECIPE_ID_REGEX.match(
-                            str(recipe_permalink)).groups()[0]
-                        mutex.acquire()
+                        # print("_run_discovery: recipe_permalink type: %s" %
+                        #       str(type(recipe_permalink)))
+                        # mutex.acquire()
                         try:
+                            recipe_id = RECIPE_ID_REGEX.match(
+                                str(recipe_permalink)).groups()[0]
+                            self.store.enqueue(recipe_permalink)
                             # recipe = scrape_me(str(recipe_permalink))
                             # recipe_dumpus = json.dumps(recipe.to_dict())
-                            print(f"Fetched JSON: {recipe_permalink}")
+                            # print(f"Fetched JSON: {recipe_permalink}")
                             found_ids.append(int(recipe_id))
                             urls_counted += 1
                             # print("_start_discovery ...3 " +
                             #       str(an_item) + "    " + str(urls_counted))
-                            if urls_counted / 100 == int(urls_counted / 100):
+                            if urls_counted / 10 == int(urls_counted / 10):
                                 # sys.stderr.write(
-                                print("urls_counted: " + str(urls_counted))
-                        finally:
-                            mutex.release()
+                                fmt = ("Status: urls_counted: "
+                                       "%s -- %s -- th:%s -- %s")
+                                stat = self.store._queue.aggregate([
+                                    {"$group": {"_id": "$state",
+                                                "count": {"$sum": 1}}}])
+                                print(fmt % (
+                                    str(urls_counted),
+                                    str(sorted(list(stat),
+                                               key=lambda a: a['_id'])),
+                                    str(threading.active_count()),
+                                    recipe_permalink,
+                                ))
+                        except Exception as eeee:
+                            print("Exceptioni encountered: %s" %
+                                  str(recipe_permalink), eeee)
+                        # finally:
+                            # mutex.release()
             except StopIteration as ee:
                 print("_start_discovery: StopIteration")
                     # print("_start_discovery 4 "+str(item))
@@ -87,14 +164,15 @@ class CrawlCoordinator:
                         import pudb; pu.db
                 return
 
-
-    @classmethod
-    def discovery_runner(cls, scraper_class):
-        def choose(recipe_id: int, uri: str):
-            return False
+    def discovery_runner(self, scraper_class):
+        # def choose(recipe_id: int, uri: str):
+        #     return False
 
         yield from scraper_class.site_url_generator(
-            choose, THREADS_DISCOVERY_HTTP_CLIENT)
+            should_exclude_recipe=lambda uri: self.store.is_enqueued(uri) or
+                                              self.store.have_recipe(uri),
+            recipe_check_threads=THREADS_DISCOVERY_HTTP_CLIENT,
+        )
 
         # print("discovery_runner startup")
         # site_iter = scraper_class.site_iterator(None, 1, 10000)

--- a/crawl_coordinator.py
+++ b/crawl_coordinator.py
@@ -1,4 +1,5 @@
 import multiprocessing.dummy as mp
+import random
 import re
 import requests
 import sys
@@ -8,8 +9,8 @@ from threading import Thread, Lock
 mutex = Lock()
 
 from datastore import RecipeStore
-
-# from recipe_scrapers import scrape_me
+import json
+from recipe_scrapers import scrape_me
 from recipe_scrapers._abstract import AbstractScraper
 
 
@@ -24,17 +25,7 @@ class CrawlCoordinator:
         self.store = RecipeStore()
 
     def start(self):
-        # import pudb; pu.db
-        url_gen = self._start_discovery() <- isn\'t a generator
-        try:
-            while True:
-                print("start...")
-                url = next(url_gen)  <- NoneType is not an iterator
-                print("CrawlCoordinator.start: " + url)
-        except StopIteration:
-            import pudb; pu.db
-            print("Finished URL discovery")
-            return
+        self._start_discovery()
 
     def _start_discovery(self):
         # site_explorers = [RecipeSiteUrlIterator(klass)
@@ -43,7 +34,8 @@ class CrawlCoordinator:
         urls_counted = 0
 
         with mp.Pool(4*len(self.scraper_classes)) as dpool:
-            RECIPE_ID_REGEX = re.compile(r".*[^/]+/(\d+)$")
+            RECIPE_ID_REGEX = re.compile(r".*/recipe/(\d+)/[a-z0-9_\-.]+/?$",
+                                         re.I)
             found_ids = []
             site_iterator = dpool.imap_unordered(
                 CrawlCoordinator.discovery_runner,
@@ -51,21 +43,30 @@ class CrawlCoordinator:
 
             try:
                 while True:
-                    # print("_start_discovery ...1")
+                    print("_start_discovery ...1")
                     item = next(site_iterator)
+                    print("_start_discovery ...1 ", str(item))
                     while True:
                         # print("_start_discovery ...2")
-                        an_item = next(item)
-                        recipe_id = RECIPE_ID_REGEX.match(an_item).groups()[0]
+                        a_recipe_uri = next(item)
+                        if not a_recipe_uri:
+                            continue
+                        recipe_id = RECIPE_ID_REGEX.match(a_recipe_uri).groups()[0]
                         mutex.acquire()
                         try:
+                            recipe = scrape_me(a_recipe_uri)
+                            # r = requests.get(a_recipe_uri)
+                            # if r.ok:
+                            #     print(f"{a_recipe_uri} - {len(r.text)}")
+                            recipe_dumpus = json.dumps(recipe.to_dict())
+                            print(f"{a_recipe_uri} - {recipe_dumpus}\n\n")
                             found_ids.append(int(recipe_id))
                             urls_counted += 1
                             # print("_start_discovery ...3 " +
                             #       str(an_item) + "    " + str(urls_counted))
                             if urls_counted / 100 == int(urls_counted / 100):
-                                sys.stderr.write(
-                                    "urls_counted: " + str(urls_counted) + "\n")
+                                # sys.stderr.write(
+                                print("urls_counted: " + str(urls_counted))
                         finally:
                             mutex.release()
             except StopIteration as ee:
@@ -82,10 +83,17 @@ class CrawlCoordinator:
 
     @classmethod
     def discovery_runner(cls, scraper_class):
-        # import pudb; pu.db
+        def choose(x):
+            return True
+            # yes = random.random() > 0.6666
+            # return yes
+
+        yield from scraper_class.site_iterator(choose, 1, 10000)
+
         # print("discovery_runner startup")
-        site_iter = scraper_class.site_iterator(None, 1, 10000)
+        # site_iter = scraper_class.site_iterator(None, 1, 10000)
         # print("discovery_runner site_iter: "+str(site_iter))
+        """
         try:
             while True:
                 # print("d-r...")
@@ -95,3 +103,4 @@ class CrawlCoordinator:
         except StopIteration:
             print("discovery_runner StopIteration")
             return
+        """

--- a/crawler_start.sh
+++ b/crawler_start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd $CRAWLER_DIR
+pwd
+ls -l $CRAWLER_DIR/
+python3 $CRAWLER_DIR/do_thing.py /opt/app-root/src/allrecipes-crawler/docker-compose.yaml-23-skidoo ABC

--- a/datastore.py
+++ b/datastore.py
@@ -1,0 +1,27 @@
+import os
+from threading import Thread, Lock
+
+from pymongo import MongoClient
+
+mutex = Lock()
+
+
+class RecipeStore:
+    _instance = None
+
+    def __init__(self):
+        # print("\n".join(str(kv) for kv in os.environ.items()))
+        self.user = os.environ.get("MONGO_APP_USERNAME")
+        self.passwd = os.environ.get("MONGO_APP_PASSWORD")
+        self.host = os.environ.get("mongo")
+        self.conn_uri = f"mongo+srv://{self.user}:{self.passwd}@"
+        self.mdb = MongoClient()
+
+    @classmethod
+    def instance(cls):
+        mutex.acquire()
+        try:
+            if cls._instance is None:
+                cls._instance = RecipeStore()
+        finally:
+            mutex.release()

--- a/datastore.py
+++ b/datastore.py
@@ -1,27 +1,212 @@
+from datetime import datetime as dt, timedelta as td
+import json
 import os
+import secrets
 from threading import Thread, Lock
+from requests.packages.urllib3.util import Url
+from requests.packages.urllib3.util import parse_url
+import logging
 
+import pymongo
 from pymongo import MongoClient
+from simple_classproperty import classproperty
 
 mutex = Lock()
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
+
+class EmptyQueueException(Exception):
+    pass
 
 
 class RecipeStore:
     _instance = None
 
+    DATABASE_NAME = 'RecipeDB'
+    COLL_NAME_QUEUE = 'queue'
+    COLL_NAME_RECIPE = 'recipe'
+    COLL_NAME_HISTORY = 'action'
+
     def __init__(self):
         # print("\n".join(str(kv) for kv in os.environ.items()))
         self.user = os.environ.get("MONGO_APP_USERNAME")
         self.passwd = os.environ.get("MONGO_APP_PASSWORD")
-        self.host = os.environ.get("mongo")
-        self.conn_uri = f"mongo+srv://{self.user}:{self.passwd}@"
-        self.mdb = MongoClient()
+        self.host = os.environ.get("localhost")
+        # self.conn_uri = f"mongo+srv://{self.user}:{self.passwd}@"
+        # import pudb; pu.db
+        self._mdb = MongoClient()
+        self._ensure_existence()
+        logger.info("Database start: %s", self._db_stats_report())
+
+    @classproperty
+    def instance(cls) -> 'RecipeStore':
+        if cls._instance is None:
+            mutex.acquire()
+            try:
+                # Why check twice? Multiple threads could can slip past the
+                # first if, and we don't want the lock penalty on every
+                if cls._instance is None:
+                    cls._instance = cls()
+            finally:
+                mutex.release()
+        return cls._instance
 
     @classmethod
-    def instance(cls):
-        mutex.acquire()
-        try:
-            if cls._instance is None:
-                cls._instance = RecipeStore()
-        finally:
+    def _get_indices(cls, coll):
+        return {index['key'].keys()[0]: index for index
+                in list(coll.list_indexes())}
+
+    def _ensure_existence(self):
+        # Database
+        self._db = self._mdb[self.DATABASE_NAME]
+
+        # Collections
+        self._queue = self._db[self.COLL_NAME_QUEUE]
+        self._recipe = self._db[self.COLL_NAME_RECIPE]
+        self._action = self._db[self.COLL_NAME_HISTORY]
+
+        # Indices - queue
+        # self._queue.ensure_index(
+        #     [("domain_name", pymongo.ASCENDING),
+        #      ("ts_added", pymongo.ASCENDING)],
+        #       name="idx_domain", unique=True)
+        # self._queue.ensure_index("ts", unique=True, name="idx_ts")
+        self._queue.ensure_index([("state", pymongo.ASCENDING),
+                                  ("ts", pymongo.ASCENDING)],
+                                 unique=True, name="idx_ts")
+        self._queue.ensure_index("uri", unique=True, name="idx_uri")
+
+        # Indices - recipe
+        self._recipe.ensure_index([("domain", pymongo.ASCENDING),
+                                   ("canonical_url", pymongo.ASCENDING)],
+                                  unique=True, name="idx_domain")
+        # self._recipe.ensure_index("recipe_id", unique=True, name="idx_recipe_id")
+        self._recipe.ensure_index("canonical_url", unique=True, name="idx_uri")
+
+        # Indices - action
+        # uri-chrono order
+        self._action.ensure_index(
+            [("uri", pymongo.ASCENDING),
+             ("ts", pymongo.ASCENDING),
+             ("act", pymongo.ASCENDING)],
+            unique=True, name="idx_uri_ts")
+        # Global chrono order
+        self._action.ensure_index(
+            [("ts", pymongo.ASCENDING),
+             ("uri", pymongo.ASCENDING),
+             ("act", pymongo.ASCENDING)],
+            unique=True, name="idx_ts")
+
+    def _db_stats_report(self):
+        return (f"Queue# {self._queue.count()}  "
+                f"Recipe# {self._recipe.count()}  "
+                f"Action# {self._action.count()}")
+
+    def have_recipe(self, recipe_uri: Url):
+        found = self._recipe.find({"canonical_url": str(recipe_uri)})
+        if not found or found.count() == 0:
+            return False
+        if found.count() > 1:
+            logger.warning("Found more than one recipe for %s", recipe_uri)
+        return True
+
+    def upsert_recipe(self, recipe):
+        uri = recipe['canonical_url']
+        # print("upsert_recipe: %s" % uri)
+        if self.have_recipe(uri):
+            logger.warning("Updating existing recipe: %s" % uri)
+        result = self._recipe.replace_one(
+            {"canonical_url": uri}, recipe, upsert=True)
+        print("upsert_recipeed: %s" % uri)
+        return result
+
+    def is_enqueued(self, recipe_uri: Url, recipe_id: int = None) -> bool:
+        return self._queue.find({"uri": str(recipe_uri)}).count() > 0
+
+    def enqueue(self, recipe_uri: Url) -> bool:
+        if self.is_enqueued(recipe_uri):
+            return False
+        now = dt.now()
+        self._queue.insert_one(
+            {"uri": str(recipe_uri), "ts": now, "state": "wait"})
+        self._action.insert_one(
+            {"uri": str(recipe_uri), "ts": now, "act": "enqueue"})
+
+    def dequeue(self) -> Url:
+        entry = None
+        now = dt.now()
+        tries_left = 10
+        while entry is None:
+            # entry = self._queue.find_one({
+            #     "$query": {"state": "wait", "ts": {"$lt": now.timestamp() + 1}},
+            #     "_addSpecial": {"$orderBy": {"ts": 1}}}
+            # )
+            mutex.acquire(blocking=True, timeout=3)
+            entries = self._queue.find({"state": "wait"})
+            entries.sort("ts")
+            # {"state": "wait", "ts": {"$gt": now}})
+            if entries is None or entries.count() == 0:
+                if tries_left > 0:
+                    now += td(seconds=1)
+                    tries_left -= 1
+                else:
+                    break
+            else:
+                entry = entries[0]
+
+        if entry:
+            self._queue.update_one({"uri": entry["uri"]},
+                                   {"$set": {"state": "scrape"}})
             mutex.release()
+            self._action.insert_one({
+                "uri": str(entry['uri']), "ts": now, "act": "scrape"})
+            return parse_url(entry["uri"])
+        else:
+            mutex.release()
+            queue_size = self._queue.find({"state": "wait"}).count()
+            queue_status = self._queue.aggregate([
+                {"$group": {"_id": "$state", "count": {"$sum": 1}}},
+            ])
+            # self._action.insert_one({
+            #     "uri": str(entry['recipe_uri']), "ts": now,
+            #     "act": "dequeue_miss(%d)" % queue_size})
+            logger.debug("dequeue_miss with known %s entries" % json.dumps(
+                list(queue_status)))
+            if not queue_size:
+                raise EmptyQueueException("Found zero entries in queue")
+            return None
+
+    def dequeue_finish(self, recipe_uri: Url):
+        now = dt.now()
+        count0 = self._queue.find({"uri": str(recipe_uri)}).count()
+        res = self._queue.delete_one({"uri": str(recipe_uri)})
+        count1 = self._queue.find({"uri": str(recipe_uri)}).count()
+        # print("DEQUEUE RESULT 0: %s, count0: %s, count1: %s",
+        #       str(res.raw_result), count0, count1)
+        self._action.insert_one({"uri": str(recipe_uri), "ts": now, "act":
+            "finish"})
+        # print("DEQUEUE RESULT 1: ")
+
+    # def _ensure_db_exists(self):
+    #     mutex.acquire()
+    #     dblist = self._mdb.list_database_names()
+    #     try:
+    #         if self.DATABASE_NAME not in dblist:
+    #             self._mdb[self.DATABASE_NAME]
+    #     finally:
+    #         mutex.release()
+
+    def _create_user(self, username):
+        """
+        https://stackoverflow.com/questions/20117104/mongodb-root-user
+
+        import secrets
+        secrets.token_urlsafe(64)
+
+        https://cryptography.io/en/latest/random-numbers/
+
+        :param username:
+        :return:
+        """
+        # self._db.

--- a/dev-container-setup.sh
+++ b/dev-container-setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd $CRAWLER_DIR
+pwd
+ls -l $CRAWLER_DIR/requirements.txt
+pip3 install -r $CRAWLER_DIR/requirements.txt
+
+cd $SCRAPER_DIR
+pwd
+ls -l $SCRAPER_DIR/requirements-dev.txt
+pip3 install -r $SCRAPER_DIR/requirements-dev.txt

--- a/dev.py
+++ b/dev.py
@@ -13,8 +13,9 @@ from requests.packages.urllib3.util import Url
 
 def main():
     # cProfile.run('CrawlCoordinator([AllRecipes]).start()')
-    coordinator = CrawlCoordinator([AllRecipes], lambda: True, lambda: True)
-    coordinator.start()
+    coordinator = CrawlCoordinator(
+        [AllRecipes], lambda uri: True, lambda uri: True)
+    coordinator.start_crawl()
 
     # a = scrape_me("https://www.allrecipes.com/recipe/12345/jeff-davis-pie-i/",
     #               proxies={"http": "http://127.0.0.1:3128",

--- a/dev.py
+++ b/dev.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import os, sys  # , json, time
+from crawl_coordinator import CrawlCoordinator
+
+sys.path.append(os.path.join(os.getcwd(), "build/lib/recipe_scrapers"))
+
+# from recipe_scrapers import scrape_me
+from recipe_scrapers import AllRecipes
+
+
+def main():
+    # cProfile.run('CrawlCoordinator([AllRecipes]).start()')
+    coordinator = CrawlCoordinator([AllRecipes])
+    coordinator.start()
+
+
+if __name__ == "__main__":
+    main()
+
+
+"""
+via: https://hub.docker.com/_/mongo/
+
+docker pull mongo
+
+EXTERNAL_MONGO_DATA_DIR=/Users/kev/projs/allrecipes-mongo
+INTERNAL_MONGO_DATA_DIR=/data/db
+
+$ docker run --name kevs-mongo -v \
+  $EXTERNAL_MONGO_DATA_DIR:$INTERNAL_MONGO_DATA_DIR -d mongo
+8ea6723c2a2640ccbba6134a12f38f7746156ef1cab4474767651ee26ec5dfc1
+
+$ docker exec -it 8ea6723c2a26 bash  # get shell in that container
+$ ls -l $INTERNAL_MONGO_DATA_DIR
+abc
+$ ls -l $$EXTERNAL_MONGO_DATA_DIR
+abc
+
+abc == abc
+"""

--- a/dev.py
+++ b/dev.py
@@ -1,150 +1,17 @@
 #!/usr/bin/env python3
 
-import os, sys  # , json, time
 from crawl_coordinator import CrawlCoordinator
-from datastore import RecipeStore
 
-sys.path.append(os.path.join(os.getcwd(), "build/lib/recipe_scrapers"))
-
-from recipe_scrapers import scrape_me
 from recipe_scrapers import AllRecipes
-from requests.packages.urllib3.util import Url
 
 
 def main():
     # cProfile.run('CrawlCoordinator([AllRecipes]).start()')
     coordinator = CrawlCoordinator(
-        [AllRecipes], lambda uri: True, lambda uri: True)
+        [AllRecipes], lambda uri: True, lambda uri: True
+    )
     coordinator.start_crawl()
 
-    # a = scrape_me("https://www.allrecipes.com/recipe/12345/jeff-davis-pie-i/",
-    #               proxies={"http": "http://127.0.0.1:3128",
-    #                        "https": "http://127.0.0.1:3128"})
-    # import pudb; pu.db
-    """
-    rs = RecipeStore.instance
-    # import pudb; pu.db
-    u1 = "https://www.allrecipes.com/recipe/12345/jeff-davis-pie-i/"
-    u2 = "https://www.allrecipes.com/recipe/12346/jeff-davis-pie-i/"
-    rs.enqueue(u1)
-    rs.enqueue(u2)
-    d2 = rs.dequeue()
-    d1 = rs.dequeue()
-    """
-
-    """
-    uris = [
-        "https://www.allrecipes.com/recipe/6786/crazay-bagels/",
-        "https://www.allrecipes.com/recipe/6902/indian-naan-i/",
-        "https://www.allrecipes.com/recipe/6908/butterscotch-buns/",
-        "https://www.allrecipes.com/recipe/6909/jam-filled-buns/",
-        "https://www.allrecipes.com/recipe/6910/kolaches-i/",
-        "https://www.allrecipes.com/recipe/6911/sour-cream-and-onion-bread/",
-        "https://www.allrecipes.com/recipe/6912/orange-loaf/",
-        "https://www.allrecipes.com/recipe/6913/cranberry-orange-loaf/",
-        "https://www.allrecipes.com/recipe/6914/cranberry-loaf/",
-        "https://www.allrecipes.com/recipe/6915/zucchini-bread-iv/",
-        "https://www.allrecipes.com/recipe/6916/croissants/",
-        "https://www.allrecipes.com/recipe/6917/portuguese-cornbread/",
-        "https://www.allrecipes.com/recipe/6918/portuguese-fried-bread/",
-        "https://www.allrecipes.com/recipe/6919/bannock/",
-        "https://www.allrecipes.com/recipe/6920/orange-cinnamon-sticks/",
-        "https://www.allrecipes.com/recipe/6921/quick-banana-bread/",
-        "https://www.allrecipes.com/recipe/6922/fake-sourdough-biscuits/",
-        "https://www.allrecipes.com/recipe/6923/monkey-bread-iii/",
-        "https://www.allrecipes.com/recipe/6924/monkey-bread-iv/",
-        "https://www.allrecipes.com/recipe/6925/monkey-bread-v/",
-        "https://www.allrecipes.com/recipe/6926/bruces-honey-sesame-bread/",
-        "https://www.allrecipes.com/recipe/6927/beaten-biscuits/",
-        "https://www.allrecipes.com/recipe/6928/bagels-ii/",
-        "https://www.allrecipes.com/recipe/6929/flower-pot-challah-bread/",
-        "https://www.allrecipes.com/recipe/6930/date-orange-bread/",
-        "https://www.allrecipes.com/recipe/6931/luxury-loaf/",
-        "https://www.allrecipes.com/recipe/6932/orange-pumpkin-loaf/",
-        "https://www.allrecipes.com/recipe/6933/pumpkin-tea-bread/",
-        "https://www.allrecipes.com/recipe/6934/cinnamon-bread-i/",
-        "https://www.allrecipes.com/recipe/6935/cherry-spice-loaf/",
-        "https://www.allrecipes.com/recipe/6936/raisin-bread-i/",
-        "https://www.allrecipes.com/recipe/6937/pineapple-bread/",
-        "https://www.allrecipes.com/recipe/6938/fruit-and-nut-loaf/",
-        "https://www.allrecipes.com/recipe/6939/fruit-bread-i/",
-        "https://www.allrecipes.com/recipe/6940/fruit-bread-ii/",
-        "https://www.allrecipes.com/recipe/6941/zucchini-coconut-loaf/",
-        "https://www.allrecipes.com/recipe/6942/favorite-nut-bread/",
-        "https://www.allrecipes.com/recipe/6943/cottage-cheese-loaf/",
-        "https://www.allrecipes.com/recipe/6944/pumpkin-loaf/",
-        "https://www.allrecipes.com/recipe/6945/fancy-crescents/",
-        "https://www.allrecipes.com/recipe/6946/blueberry-scones/",
-        "https://www.allrecipes.com/recipe/6947/english-muffins/",
-        "https://www.allrecipes.com/recipe/6948/cinnamon-sour-cream-biscuits/",
-        "https://www.allrecipes.com/recipe/6949/fruit-loaf/",
-        "https://www.allrecipes.com/recipe/6950/sophies-zucchini-bread/",
-        "https://www.allrecipes.com/recipe/6951/abbys-super-zucchini-loaf/",
-        "https://www.allrecipes.com/recipe/6952/butter-tart-muffins/",
-        "https://www.allrecipes.com/recipe/6953/hot-water-cornbread/",
-        "https://www.allrecipes.com/recipe/6954/maple-twists/",
-        "https://www.allrecipes.com/recipe/6955/mama-ds-italian-bread/",
-        "https://www.allrecipes.com/recipe/6956/pepperoni-filled-bread/",
-        "https://www.allrecipes.com/recipe/6957/banana-chip-muffins-i/",
-        "https://www.allrecipes.com/recipe/6958/cinnamon-buns/",
-        "https://www.allrecipes.com/recipe/6959/mustard-wheat-rye-sandwich-bread/",
-        "https://www.allrecipes.com/recipe/6960/dr-michaels-yeasted-cornbread/",
-        "https://www.allrecipes.com/recipe/6961/the-best-pizza-crust/",
-        "https://www.allrecipes.com/recipe/6962/seven-grain-bread-i/",
-        "https://www.allrecipes.com/recipe/6963/good-100-whole-wheat-bread/",
-        "https://www.allrecipes.com/recipe/6964/persimmon-bread-ii/",
-        "https://www.allrecipes.com/recipe/6965/peanut-butter-sandwich-loaf/",
-        "https://www.allrecipes.com/recipe/6966/soft-pretzels-ii/",
-        "https://www.allrecipes.com/recipe/6967/mincemeat-quick-bread/",
-        "https://www.allrecipes.com/recipe/6968/poppy-seed-rolls/",
-        "https://www.allrecipes.com/recipe/6969/peach-bread/",
-        "https://www.allrecipes.com/recipe/6970/butterfly-buns/",
-        "https://www.allrecipes.com/recipe/6971/honey-of-an-oatmeal-bread/",
-        "https://www.allrecipes.com/recipe/6972/buttermilk-bread-ii/",
-        "https://www.allrecipes.com/recipe/6973/poppy-seed-loaf/",
-        "https://www.allrecipes.com/recipe/6974/irish-bannock/",
-        "https://www.allrecipes.com/recipe/6975/swedish-limpu-bread/",
-        "https://www.allrecipes.com/recipe/6976/hot-water-cornmeal-bread/",
-        "https://www.allrecipes.com/recipe/6977/cracklin-bread-i/",
-    ]
-    for recipe_uri in uris:
-        r = scrape_me(recipe_uri)
-        x = r.to_dict(unitized=True, uri=str(recipe_uri))
-        print(r)
-    """
-
-    """
-    rs = RecipeStore.instance
-    # import pudb; pu.db
-    u1 = "https://www.allrecipes.com/recipe/12345/jeff-davis-pie-i/"
-    u2 = "https://www.allrecipes.com/recipe/12346/jeff-davis-pie-i/"
-    rs.enqueue(u1)
-    rs.enqueue(u2)
-    d2 = rs.dequeue()
-    d1 = rs.dequeue()
-    """
 
 if __name__ == "__main__":
     main()
-
-
-"""
-via: https://hub.docker.com/_/mongo/
-
-docker pull mongo
-
-EXTERNAL_MONGO_DATA_DIR=/Users/kev/projs/allrecipes-mongo
-INTERNAL_MONGO_DATA_DIR=/data/db
-
-$ docker run --name kevs-mongo -v \
-  $EXTERNAL_MONGO_DATA_DIR:$INTERNAL_MONGO_DATA_DIR -d mongo
-8ea6723c2a2640ccbba6134a12f38f7746156ef1cab4474767651ee26ec5dfc1
-
-$ docker exec -it 8ea6723c2a26 bash  # get shell in that container
-$ ls -l $INTERNAL_MONGO_DATA_DIR
-abc
-$ ls -l $$EXTERNAL_MONGO_DATA_DIR
-abc
-
-abc == abc
-"""

--- a/dev.py
+++ b/dev.py
@@ -2,18 +2,126 @@
 
 import os, sys  # , json, time
 from crawl_coordinator import CrawlCoordinator
+from datastore import RecipeStore
 
 sys.path.append(os.path.join(os.getcwd(), "build/lib/recipe_scrapers"))
 
-# from recipe_scrapers import scrape_me
+from recipe_scrapers import scrape_me
 from recipe_scrapers import AllRecipes
+from requests.packages.urllib3.util import Url
 
 
 def main():
     # cProfile.run('CrawlCoordinator([AllRecipes]).start()')
-    coordinator = CrawlCoordinator([AllRecipes])
+    coordinator = CrawlCoordinator([AllRecipes], lambda: True, lambda: True)
     coordinator.start()
 
+    # a = scrape_me("https://www.allrecipes.com/recipe/12345/jeff-davis-pie-i/",
+    #               proxies={"http": "http://127.0.0.1:3128",
+    #                        "https": "http://127.0.0.1:3128"})
+    # import pudb; pu.db
+    """
+    rs = RecipeStore.instance
+    # import pudb; pu.db
+    u1 = "https://www.allrecipes.com/recipe/12345/jeff-davis-pie-i/"
+    u2 = "https://www.allrecipes.com/recipe/12346/jeff-davis-pie-i/"
+    rs.enqueue(u1)
+    rs.enqueue(u2)
+    d2 = rs.dequeue()
+    d1 = rs.dequeue()
+    """
+
+    """
+    uris = [
+        "https://www.allrecipes.com/recipe/6786/crazay-bagels/",
+        "https://www.allrecipes.com/recipe/6902/indian-naan-i/",
+        "https://www.allrecipes.com/recipe/6908/butterscotch-buns/",
+        "https://www.allrecipes.com/recipe/6909/jam-filled-buns/",
+        "https://www.allrecipes.com/recipe/6910/kolaches-i/",
+        "https://www.allrecipes.com/recipe/6911/sour-cream-and-onion-bread/",
+        "https://www.allrecipes.com/recipe/6912/orange-loaf/",
+        "https://www.allrecipes.com/recipe/6913/cranberry-orange-loaf/",
+        "https://www.allrecipes.com/recipe/6914/cranberry-loaf/",
+        "https://www.allrecipes.com/recipe/6915/zucchini-bread-iv/",
+        "https://www.allrecipes.com/recipe/6916/croissants/",
+        "https://www.allrecipes.com/recipe/6917/portuguese-cornbread/",
+        "https://www.allrecipes.com/recipe/6918/portuguese-fried-bread/",
+        "https://www.allrecipes.com/recipe/6919/bannock/",
+        "https://www.allrecipes.com/recipe/6920/orange-cinnamon-sticks/",
+        "https://www.allrecipes.com/recipe/6921/quick-banana-bread/",
+        "https://www.allrecipes.com/recipe/6922/fake-sourdough-biscuits/",
+        "https://www.allrecipes.com/recipe/6923/monkey-bread-iii/",
+        "https://www.allrecipes.com/recipe/6924/monkey-bread-iv/",
+        "https://www.allrecipes.com/recipe/6925/monkey-bread-v/",
+        "https://www.allrecipes.com/recipe/6926/bruces-honey-sesame-bread/",
+        "https://www.allrecipes.com/recipe/6927/beaten-biscuits/",
+        "https://www.allrecipes.com/recipe/6928/bagels-ii/",
+        "https://www.allrecipes.com/recipe/6929/flower-pot-challah-bread/",
+        "https://www.allrecipes.com/recipe/6930/date-orange-bread/",
+        "https://www.allrecipes.com/recipe/6931/luxury-loaf/",
+        "https://www.allrecipes.com/recipe/6932/orange-pumpkin-loaf/",
+        "https://www.allrecipes.com/recipe/6933/pumpkin-tea-bread/",
+        "https://www.allrecipes.com/recipe/6934/cinnamon-bread-i/",
+        "https://www.allrecipes.com/recipe/6935/cherry-spice-loaf/",
+        "https://www.allrecipes.com/recipe/6936/raisin-bread-i/",
+        "https://www.allrecipes.com/recipe/6937/pineapple-bread/",
+        "https://www.allrecipes.com/recipe/6938/fruit-and-nut-loaf/",
+        "https://www.allrecipes.com/recipe/6939/fruit-bread-i/",
+        "https://www.allrecipes.com/recipe/6940/fruit-bread-ii/",
+        "https://www.allrecipes.com/recipe/6941/zucchini-coconut-loaf/",
+        "https://www.allrecipes.com/recipe/6942/favorite-nut-bread/",
+        "https://www.allrecipes.com/recipe/6943/cottage-cheese-loaf/",
+        "https://www.allrecipes.com/recipe/6944/pumpkin-loaf/",
+        "https://www.allrecipes.com/recipe/6945/fancy-crescents/",
+        "https://www.allrecipes.com/recipe/6946/blueberry-scones/",
+        "https://www.allrecipes.com/recipe/6947/english-muffins/",
+        "https://www.allrecipes.com/recipe/6948/cinnamon-sour-cream-biscuits/",
+        "https://www.allrecipes.com/recipe/6949/fruit-loaf/",
+        "https://www.allrecipes.com/recipe/6950/sophies-zucchini-bread/",
+        "https://www.allrecipes.com/recipe/6951/abbys-super-zucchini-loaf/",
+        "https://www.allrecipes.com/recipe/6952/butter-tart-muffins/",
+        "https://www.allrecipes.com/recipe/6953/hot-water-cornbread/",
+        "https://www.allrecipes.com/recipe/6954/maple-twists/",
+        "https://www.allrecipes.com/recipe/6955/mama-ds-italian-bread/",
+        "https://www.allrecipes.com/recipe/6956/pepperoni-filled-bread/",
+        "https://www.allrecipes.com/recipe/6957/banana-chip-muffins-i/",
+        "https://www.allrecipes.com/recipe/6958/cinnamon-buns/",
+        "https://www.allrecipes.com/recipe/6959/mustard-wheat-rye-sandwich-bread/",
+        "https://www.allrecipes.com/recipe/6960/dr-michaels-yeasted-cornbread/",
+        "https://www.allrecipes.com/recipe/6961/the-best-pizza-crust/",
+        "https://www.allrecipes.com/recipe/6962/seven-grain-bread-i/",
+        "https://www.allrecipes.com/recipe/6963/good-100-whole-wheat-bread/",
+        "https://www.allrecipes.com/recipe/6964/persimmon-bread-ii/",
+        "https://www.allrecipes.com/recipe/6965/peanut-butter-sandwich-loaf/",
+        "https://www.allrecipes.com/recipe/6966/soft-pretzels-ii/",
+        "https://www.allrecipes.com/recipe/6967/mincemeat-quick-bread/",
+        "https://www.allrecipes.com/recipe/6968/poppy-seed-rolls/",
+        "https://www.allrecipes.com/recipe/6969/peach-bread/",
+        "https://www.allrecipes.com/recipe/6970/butterfly-buns/",
+        "https://www.allrecipes.com/recipe/6971/honey-of-an-oatmeal-bread/",
+        "https://www.allrecipes.com/recipe/6972/buttermilk-bread-ii/",
+        "https://www.allrecipes.com/recipe/6973/poppy-seed-loaf/",
+        "https://www.allrecipes.com/recipe/6974/irish-bannock/",
+        "https://www.allrecipes.com/recipe/6975/swedish-limpu-bread/",
+        "https://www.allrecipes.com/recipe/6976/hot-water-cornmeal-bread/",
+        "https://www.allrecipes.com/recipe/6977/cracklin-bread-i/",
+    ]
+    for recipe_uri in uris:
+        r = scrape_me(recipe_uri)
+        x = r.to_dict(unitized=True, uri=str(recipe_uri))
+        print(r)
+    """
+
+    """
+    rs = RecipeStore.instance
+    # import pudb; pu.db
+    u1 = "https://www.allrecipes.com/recipe/12345/jeff-davis-pie-i/"
+    u2 = "https://www.allrecipes.com/recipe/12346/jeff-davis-pie-i/"
+    rs.enqueue(u1)
+    rs.enqueue(u2)
+    d2 = rs.dequeue()
+    d1 = rs.dequeue()
+    """
 
 if __name__ == "__main__":
     main()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,8 +15,8 @@ services:
 #      MONGO_INITDB_ROOT_PASSWORD: password
     networks:
       - recipes-net
-    expose:
-      - "27017"
+#    expose:
+#      - "27017"
     ports:
       - "27017:27017"
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,11 +10,15 @@ services:
   mongo:
     image: mongo
     restart: always
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: password
+#    environment:
+#      MONGO_INITDB_ROOT_USERNAME: root
+#      MONGO_INITDB_ROOT_PASSWORD: password
     networks:
       - recipes-net
+    expose:
+      - "27017"
+    ports:
+      - "27017:27017"
     volumes:
       - ./data:/data/db
 
@@ -61,6 +65,43 @@ services:
     links:
       - mongo
 
+  squid:
+    container_name: squid
+    image: sameersbn/squid:3.5.27-2
+    restart: always
+    expose:
+      - "3128"
+    ports:
+      - "3128:3128"
+    volumes:
+      - /Users/kev/var/spool/squid/cache:/var/spool/squid
+      - /Users/kev/projs/recipe-crawler/squid.conf:/etc/squid/squid.conf
+#    networks:
+#      - recipes-net
+
+#  dev-proxy:
+#    image: jwilder/nginx-proxy
+#    restart: always
+#    networks:
+#      - recipes-net
+#    volumes:
+#      - /var/run/docker.sock:/tmp/docker.sock:ro
+#    expose:
+#      - "443"
+#    ports:
+#      - "6969:80"
+
 networks:
   recipes-net:
     driver: bridge
+
+
+#db.createUser( { user: "root",
+#          pwd: "",
+#          roles: [ "userAdminAnyDatabase",
+#                   "dbAdminAnyDatabase",
+#                   "readWriteAnyDatabase"
+#
+#] } )
+#
+#openssl rand -base64 48

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,66 @@
+version: '3'
+
+# docker-compose build; docker-compose up -d docker-compose.yaml
+# Then check the logs with
+# docker logs --tail 50 $service_namee
+# docker-compose images
+# docker-compose logs --tail 20 service_namee
+
+services:
+  mongo:
+    image: mongo
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: password
+    networks:
+      - recipes-net
+    volumes:
+      - ./data:/data/db
+
+  dev:
+    container_name: dev
+    environment:
+      MONGO_APP_USERNAME: cook
+      MONGO_APP_PASSWORD: bottlewasher
+    volumes:
+      - .:/opt/app-root/src/recipe-crawler
+      - ../recipe-scrapers:/opt/app-root/src/recipe-scrapers
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev
+    depends_on:
+      - mongo
+    networks:
+      - recipes-net
+    entrypoint:
+      /opt/app-root/src/recipe-crawler/crawler_start.sh
+    links:
+      - mongo
+
+      #    entrypoint:
+      #      python3 /opt/app-root/src/allrecipes-crawler/do_thing.py /opt/app-root/src/allrecipes-crawler/docker-compose.yaml-23-skidoo ABC
+          # watchmedo auto-restart --recursive --pattern="*.py" --directory="." python3 /opt/app-root/src/allrecipes-crawler/do_thing.py /opt/app-root/src/allrecipes-crawler/docker-compose.yaml-23-skidoo ABC
+
+  prod:
+    container_name: crawler
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: prod
+    depends_on:
+      - mongo
+    networks:
+      - recipes-net
+#    volumes:
+#      - ./:/opt/app-root/src/app
+    command:
+#      python3 /opt/app-root/src/app/do_thing.py /opt/app-root/src/app/docker-compose.yaml-23-skidoo ABC
+      python3 -c 'import sys; print("\n".join(sys.modules))' >> /tmp/python_mods.log
+    links:
+      - mongo
+
+networks:
+  recipes-net:
+    driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,8 +15,6 @@ services:
 #      MONGO_INITDB_ROOT_PASSWORD: password
     networks:
       - recipes-net
-#    expose:
-#      - "27017"
     ports:
       - "27017:27017"
     volumes:
@@ -43,10 +41,6 @@ services:
     links:
       - mongo
 
-      #    entrypoint:
-      #      python3 /opt/app-root/src/allrecipes-crawler/do_thing.py /opt/app-root/src/allrecipes-crawler/docker-compose.yaml-23-skidoo ABC
-          # watchmedo auto-restart --recursive --pattern="*.py" --directory="." python3 /opt/app-root/src/allrecipes-crawler/do_thing.py /opt/app-root/src/allrecipes-crawler/docker-compose.yaml-23-skidoo ABC
-
   prod:
     container_name: crawler
     build:
@@ -60,48 +54,10 @@ services:
 #    volumes:
 #      - ./:/opt/app-root/src/app
     command:
-#      python3 /opt/app-root/src/app/do_thing.py /opt/app-root/src/app/docker-compose.yaml-23-skidoo ABC
       python3 -c 'import sys; print("\n".join(sys.modules))' >> /tmp/python_mods.log
     links:
       - mongo
 
-  squid:
-    container_name: squid
-    image: sameersbn/squid:3.5.27-2
-    restart: always
-    expose:
-      - "3128"
-    ports:
-      - "3128:3128"
-    volumes:
-      - /Users/kev/var/spool/squid/cache:/var/spool/squid
-      - /Users/kev/projs/recipe-crawler/squid.conf:/etc/squid/squid.conf
-#    networks:
-#      - recipes-net
-
-#  dev-proxy:
-#    image: jwilder/nginx-proxy
-#    restart: always
-#    networks:
-#      - recipes-net
-#    volumes:
-#      - /var/run/docker.sock:/tmp/docker.sock:ro
-#    expose:
-#      - "443"
-#    ports:
-#      - "6969:80"
-
 networks:
   recipes-net:
     driver: bridge
-
-
-#db.createUser( { user: "root",
-#          pwd: "",
-#          roles: [ "userAdminAnyDatabase",
-#                   "dbAdminAnyDatabase",
-#                   "readWriteAnyDatabase"
-#
-#] } )
-#
-#openssl rand -base64 48

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pymongo==3.12.0
+requests==2.26.0
+watchdog==2.1.3
+numpy==1.21.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ requests==2.26.0
 watchdog==2.1.3
 numpy==1.21.1
 simple-classproperty==1.3.2
-cryptography==3.4.7
+requests-cache>=0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pymongo==3.12.0
 requests==2.26.0
 watchdog==2.1.3
 numpy==1.21.1
+simple-classproperty==1.3.2
+cryptography==3.4.7

--- a/some_stats.py
+++ b/some_stats.py
@@ -2,8 +2,9 @@
 
 from collections import defaultdict as dd
 import logging
-import os, psutil, sys
-import pymongo
+import os
+import psutil
+import sys
 from pymongo import MongoClient
 import re
 import time
@@ -20,10 +21,10 @@ WORD_SPLIT_REGEX = re.compile(r"[^a-z0-9_\-']+", re.I)
 class PullSomeStats:
 
     REPORT_FREQ = 100
-    DATABASE_NAME = 'RecipeDB'
-    COLL_NAME_QUEUE = 'queue'
-    COLL_NAME_RECIPE = 'recipe'
-    COLL_NAME_HISTORY = 'action'
+    DATABASE_NAME = "RecipeDB"
+    COLL_NAME_QUEUE = "queue"
+    COLL_NAME_RECIPE = "recipe"
+    COLL_NAME_HISTORY = "action"
 
     @classmethod
     def _get_mem_usage(cls):
@@ -37,24 +38,19 @@ class PullSomeStats:
         self._queue = self._db[self.COLL_NAME_QUEUE]
         self._recipe = self._db[self.COLL_NAME_RECIPE]
         self._action = self._db[self.COLL_NAME_HISTORY]
-        # self.recipe = self._mdb.RecipeDB.recipes
         self.start_mem = self._get_mem_usage()
         self.time_start = time.time()
 
-    def titles_gen(self):
-        x = self._recipe.distinct("title",
-            {"title": {"$not": re.compile(r".*johnsonville.*", re.I)}})
-        return x
-        # x = self._recipe.find(
-        #     {"title": {"$not": re.compile(r".*johnsonville.*", re.I)}},
-        #     {"title": 1, "_id": 0})
-        # return x
+    def titles(self):
+        return self._recipe.distinct(
+            "title", {"title": {"$not": re.compile(r".*johnsonville.*", re.I)}}
+        )
 
     def title_pop_words(self):
         wordset = dd(int)
         titles_counted = 0
         words_counted = 0
-        recipe_title_iter = self.titles_gen()
+        recipe_title_iter = self.titles()
 
         for title in recipe_title_iter:
             if not title:
@@ -67,15 +63,19 @@ class PullSomeStats:
                 wordset[word.lower()] += 1
                 words_counted += 1
             titles_counted += 1
-            if (titles_counted / self.REPORT_FREQ ==
-                    int(titles_counted / self.REPORT_FREQ)):
+            if titles_counted / self.REPORT_FREQ == int(
+                titles_counted / self.REPORT_FREQ
+            ):
                 wordset_count = len(wordset.keys())
                 secs = time.time() - self.time_start
                 progressLogger.info(
                     "Titles %d %d/sec   Words %d %d/sec   Uniques %d %d/sec",
-                    titles_counted, titles_counted/secs,
-                    words_counted, words_counted/secs,
-                    wordset_count, wordset_count/secs,
+                    titles_counted,
+                    titles_counted / secs,
+                    words_counted,
+                    words_counted / secs,
+                    wordset_count,
+                    wordset_count / secs,
                 )
                 time.sleep(0)
         self.wordset = wordset

--- a/some_stats.py
+++ b/some_stats.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+from collections import defaultdict as dd
+import logging
+import os, psutil, sys
+import pymongo
+from pymongo import MongoClient
+import re
+import time
+
+
+logging.basicConfig()
+progressLogger = logging.getLogger(__name__)
+progressLogger.addHandler(logging.StreamHandler(sys.stderr))
+
+
+WORD_SPLIT_REGEX = re.compile(r"[^a-z0-9_\-']+", re.I)
+
+
+class PullSomeStats:
+
+    REPORT_FREQ = 100
+    DATABASE_NAME = 'RecipeDB'
+    COLL_NAME_QUEUE = 'queue'
+    COLL_NAME_RECIPE = 'recipe'
+    COLL_NAME_HISTORY = 'action'
+
+    @classmethod
+    def _get_mem_usage(cls):
+        return psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2
+
+    def __init__(self):
+        self._mdb = MongoClient()
+        self._db = self._mdb[self.DATABASE_NAME]
+
+        # Collections
+        self._queue = self._db[self.COLL_NAME_QUEUE]
+        self._recipe = self._db[self.COLL_NAME_RECIPE]
+        self._action = self._db[self.COLL_NAME_HISTORY]
+        # self.recipe = self._mdb.RecipeDB.recipes
+        self.start_mem = self._get_mem_usage()
+        self.time_start = time.time()
+
+    def titles_gen(self):
+        x = self._recipe.find({
+            "title": {
+                "$not": {
+                    "$regex": r"/johnsonville/i"
+                }
+            }
+        },
+        {"title": 1, "_id": 0})
+        # x = self._recipe.find({}, {"title": 1, "_id": 0})
+        # import pudb; pu.db
+        return x
+
+    def title_pop_words(self):
+        wordset = dd(int)
+        titles_counted = 0
+        words_counted = 0
+        recipe_title_iter = self.titles_gen()
+
+        for _title in recipe_title_iter:
+            title = _title.get('title', None)
+            if not title:
+                continue
+            words = WORD_SPLIT_REGEX.split(title)
+            if not words:
+                progressLogger.error("Got empty word splits on: %s", title)
+                continue
+            for word in words:
+                wordset[word.lower()] += 1
+                words_counted += 1
+            titles_counted += 1
+            if (titles_counted / self.REPORT_FREQ ==
+                    int(titles_counted / self.REPORT_FREQ)):
+                wordset_count = len(wordset.keys())
+                secs = time.time() - self.time_start
+                progressLogger.info(
+                    "Titles %d %d/sec   Words %d %d/sec   Uniques %d %d/sec",
+                    titles_counted, titles_counted/secs,
+                    words_counted, words_counted/secs,
+                    wordset_count, wordset_count/secs,
+                )
+                time.sleep(0)
+        self.wordset = wordset
+
+    def word_stats_report(self):
+        for word in self.wordset:
+            print(f"{self.wordset[word]}\t{word}")
+
+
+if __name__ == "__main__":
+    stats = PullSomeStats()
+    stats.title_pop_words()
+    stats.word_stats_report()

--- a/some_stats.py
+++ b/some_stats.py
@@ -42,17 +42,13 @@ class PullSomeStats:
         self.time_start = time.time()
 
     def titles_gen(self):
-        x = self._recipe.find({
-            "title": {
-                "$not": {
-                    "$regex": r"/johnsonville/i"
-                }
-            }
-        },
-        {"title": 1, "_id": 0})
-        # x = self._recipe.find({}, {"title": 1, "_id": 0})
-        # import pudb; pu.db
+        x = self._recipe.distinct("title",
+            {"title": {"$not": re.compile(r".*johnsonville.*", re.I)}})
         return x
+        # x = self._recipe.find(
+        #     {"title": {"$not": re.compile(r".*johnsonville.*", re.I)}},
+        #     {"title": 1, "_id": 0})
+        # return x
 
     def title_pop_words(self):
         wordset = dd(int)
@@ -60,8 +56,7 @@ class PullSomeStats:
         words_counted = 0
         recipe_title_iter = self.titles_gen()
 
-        for _title in recipe_title_iter:
-            title = _title.get('title', None)
+        for title in recipe_title_iter:
             if not title:
                 continue
             words = WORD_SPLIT_REGEX.split(title)


### PR DESCRIPTION
## Summary
Adds a crawler, satisfies #1 .

### Details
- Uses MongoDB to queue request URIs, to store recipe JSON, and log the progress of each URI
- Uses requests-cache so that a crawl can be captured and played back (no mitm issues)
- Relies on a few features not yet in master on recipe-scrapers, such as `AbstractRecipe.sitemap_iter()` and `AbstractRecipe.to_dict()`
- Only mongo is reliably dockerized at this point, prod and dev need returning to
